### PR TITLE
[Switch] Upgrade react-ios-switch to fix change handler

### DIFF
--- a/packages/react-x-switch/package.json
+++ b/packages/react-x-switch/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react-ios-switch": "^0.1.18"
+    "react-ios-switch": "^0.1.19"
   },
   "peerDependencies": {
     "react": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5222,9 +5222,9 @@ react-dom@16.0.0-alpha.12:
     object-assign "^4.1.0"
     prop-types "^15.5.6"
 
-react-ios-switch@^0.1.18:
-  version "0.1.18"
-  resolved "https://registry.yarnpkg.com/react-ios-switch/-/react-ios-switch-0.1.18.tgz#f68371157ca83796610dc1a60a5f6cbf5742c65a"
+react-ios-switch@^0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/react-ios-switch/-/react-ios-switch-0.1.19.tgz#f11e9b1717634089da41289f674606e0da47d83a"
   dependencies:
     color-name "^1.1.3"
     inline-style-prefixer "^3.0.7"


### PR DESCRIPTION
@negativetwelve I just noticed I broke the change handler with v0.1.18.

```javascript
// v0.1.18
<Switch onChange={({ checked }) => ...} />

// v0.1.19
<Switch onChange={checked => ...} />
```
